### PR TITLE
Added warns feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V1.6 - June 2nd, 2021
+
+1. Introduced a warnings feature that allows admins and mods to warn users for sending inappropriate messages.
+
 ## V1.5 - Apr 29th, 2021
 
 1. Made the bot DM the user when they have been banned / unbanned

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ As of April 30th, 2021, 2100 anonymous messages have been sent!
 
 - Supports sending messages to two channels (anon-msgs & deep-talks) which can be configured
 - Ban users
+- Warn users
 - Anonymity for users
 - Slow mode
 - Replies

--- a/bot.js
+++ b/bot.js
@@ -694,7 +694,7 @@ function handleWarnCommand(params, msg) {
 }
 
 function handleWarnLimitCommand(params, msg) {
-    if (params.length != 4 || !isNumeric(params[2]) || !isNumeric(params[3])) {
+    if (params.length !== 4 || !isNumeric(params[2]) || !isNumeric(params[3])) {
         replyTorMessageWithStatus(msg, 2012);
         return;
     }
@@ -708,12 +708,12 @@ function handleWarnLimitCommand(params, msg) {
     }
 
     database.setWarnLimits(tempLimit, permLimit);
-    message = `Tempban warn limit set  to ${tempLimit}\nPermban warn limit set to ${permLimit}`;
+    const message = `Tempban warn limit set  to ${tempLimit}\nPermban warn limit set to ${permLimit}`;
     msg.channel.send(message);
 
     const warnedUsersInfo= database.getWarnedUsersInfo();
 
-    let warnChangeAnnouncement = `The limits on the number of warns users can receive before being temporarily and ` +
+    const warnChangeAnnouncement = `The limits on the number of warns users can receive before being temporarily and ` +
                                  `permanently banned has changed. The warn limit for temporary bans is now ` +
                                  `${tempLimit} warns and the warn limit for permanent bans is now ${permLimit} ` +
                                  `warns.\n\n`;
@@ -756,8 +756,8 @@ function handleWarnLimitCommand(params, msg) {
                       `started, you have been temporarily banned from sending anonymous messages. Your ban will be ` +
                       `lifted in ${database.getWarnTempbanDuration()} days.`;
         } else {
-            let warnsUntilTempban = tempLimit - tempCount;
-            let warnsUntilPermban = permLimit - permCount;
+            const warnsUntilTempban = tempLimit - tempCount;
+            const warnsUntilPermban = permLimit - permCount;
 
             response = warnChangeAnnouncement +
                       `After these changes:\n`;
@@ -775,7 +775,7 @@ function handleWarnLimitCommand(params, msg) {
 }
 
 function handleSetWarnTempbanDuration(params, msg) {
-    if (params.length != 3 || !isNumeric(params[2])) {
+    if (params.length !== 3 || !isNumeric(params[2])) {
         replyTorMessageWithStatus(msg, 2013);
         return;
     }

--- a/bot.js
+++ b/bot.js
@@ -100,7 +100,7 @@ async function submitAnon(msg) {
                     true
                 );
                 if (messageToSend === -1) {
-                    replyTorMessageWithStatus(msg, 2011);
+                    replyTorMessageWithStatus(msg, 2014);
                     return;
                 }
                 messageToStore =
@@ -123,7 +123,7 @@ async function submitAnon(msg) {
                     params.slice(3, params.length)
                 );
                 if (messageToSend === -1) {
-                    replyTorMessageWithStatus(msg, 2011);
+                    replyTorMessageWithStatus(msg, 2014);
                     return;
                 }
                 messageToStore = reconstructMessage(params.slice(3, params.length));
@@ -150,7 +150,7 @@ async function submitAnon(msg) {
     }
 
     if (!isCool(messageToSend)) {
-        replyTorMessageWithStatus(msg, 2012);
+        replyTorMessageWithStatus(msg, 2016);
         handleTempBan(msg, anonId, 86400, "Hate speech");
         sendLogMessage(`User ${anonId} has been temp banned for saying ${msg}`);
         return;
@@ -365,10 +365,6 @@ function formatReply(replyNum, msgArray, isNsfw) {
     );
 }
 
-function concatRegex(regex1, regex2) {
-    return new RegExp(regex1.source + regex2.source);
-}
-
 function createMsgEmbed(title, content) {
     const msg = new discord.MessageEmbed()
         .setColor(3447003)
@@ -422,6 +418,15 @@ async function parseArguments(msg) {
                 break;
             case "slur":
                 handleSlurCommand(params, msg);
+                break;
+            case "warn":
+                handleWarnCommand(params, msg);
+                break;
+            case "warnlimit":
+                handleWarnLimitCommand(params, msg);
+                break;
+            case "wtd":
+                handleSetWarnTempbanDuration(params, msg);
                 break;
             default:
                 replyTorMessageWithStatus(msg, 2000);
@@ -487,8 +492,14 @@ function handleSlowmodeCommand(params, msg) {
 }
 
 function handleTempBan(msg, anonId, duration, reason) {
+
+    if (database.isBanned(anonId)) {
+        replyTorMessageWithStatus(msg, 2021);
+        return;
+    }
+
     let unbanTime = moment().utc();
-    unbanTime = moment(unbanTime).add(duration, "s");
+    unbanTime = moment(unbanTime).add(duration, "d");
 
     const DMChannelId = database.getDmChannel(anonId);
 
@@ -499,11 +510,11 @@ function handleTempBan(msg, anonId, duration, reason) {
         unbanTime.format("DD MM YYYY HH:mm:ss")
   );
   const banMsg =
-      reason + "\nUnban date in UTC: " + unbanTime.format("DD MM YYYY HH:mm:ss");
+      reason + "\nUnban date on UTC: " + unbanTime.format("MMMM Do YYYY, [at] h:mm a");
   replyTorMessageWithStatus(msg, 1005, banMsg);
   if (DMChannelId) {
       const dm = new discord.DMChannel(client, { id: DMChannelId });
-      dm.send("You have been temporarily banned.\nReason: " + banMsg);
+      dm.send(errors.getError(4000, banMsg));
   }
 }
 
@@ -528,6 +539,7 @@ function handleBanCommand(params, msg) {
             arg3,
             reconstructMessage(params.slice(4, params.length))
         );
+        database.clearWarnCount(anonId, metadata.blockReason.TEMPBAN);
         return;
     }
     // Permaban
@@ -535,15 +547,18 @@ function handleBanCommand(params, msg) {
         replyTorMessageWithStatus(msg, 2007);
         return;
     }
+
     reason = reconstructMessage(params.slice(3, params.length));
     database.setMessageBlocker(anonId, metadata.blockReason.PERMBAN, reason, "");
     replyTorMessageWithStatus(msg, 1006, reason);
+    database.clearWarnCount(anonId, metadata.blockReason.PERMBAN);
 
     if (DMChannelId) {
         const dm = new discord.DMChannel(client, { id: DMChannelId });
-        dm.send("You have been permanently banned.\nReason: " + reason);
+        dm.send(errors.getError(4001, reason));
     }
 }
+
 
 function handleUnbanCommand(params, msg) {
     const msgId = params[2];
@@ -565,8 +580,9 @@ function handleUnbanCommand(params, msg) {
 
     if (DMChannelId) {
         const dm = new discord.DMChannel(client, { id: DMChannelId });
-        dm.send("You have been unbanned.");
+        dm.send(errors.getError(4002));
     }
+
 }
 
 function handleSlurCommand(params, msg) {
@@ -577,10 +593,211 @@ function handleSlurCommand(params, msg) {
     reinitializeFilter();
 }
 
+function handleWarnCommand(params, msg) {
+    let reason = reconstructMessage(params.slice(3));
+    const msgId = params[2];
+
+    if (reason === "") {
+        reason = "No reason given";
+    }
+
+    if (params.length < 3 || !isNumeric(msgId) ) {
+        replyTorMessageWithStatus(msg, 2011);
+        return;
+    }
+
+    if (database.getTempbanWarnLimit() === -1 || database.getPermbanWarnLimit() === - 1 ||
+        database.getWarnTempbanDuration() === -1) {
+        replyTorMessageWithStatus(msg, 2017);
+        return;
+    }
+
+    const anonId = database.getAnonIdFromMsgId(msgId);
+
+    if (database.isBanned(anonId)) {
+        replyTorMessageWithStatus(msg, 2020);
+        return;
+    }
+
+    const DMChannelId = database.getDmChannel(anonId);
+    const warnResult = database.addWarn(msgId);
+    
+    if (warnResult === metadata.blockReason.TEMPBAN) {
+        const moderationSideBanReason = "Tempban warn limit reached";
+        let unbanTime = moment().utc();
+        unbanTime = moment(unbanTime).add(database.getWarnTempbanDuration(), "d");
+
+        database.setMessageBlocker(anonId, metadata.blockReason.TEMPBAN,
+            moderationSideBanReason, unbanTime.format("DD MM YYYY HH:mm:ss"));
+
+        if (DMChannelId) {
+            const dm = new discord.DMChannel(client, {id: DMChannelId});
+            const anonUserSideBanReason = `You are receiving a warning for sending message ${msgId}\n` +
+                                          `Reason: ${reason}\n` +
+                                          `You have now exceeded the limit on the number of warns users can receive ` +
+                                          `before being temporarily banned. Your ban will be lifted in ` +
+                                          `${database.getWarnTempbanDuration()} days.`
+            dm.send(anonUserSideBanReason);
+            database.clearWarnCount(anonId, metadata.blockReason.TEMPBAN);
+        }
+
+        replyTorMessageWithStatus(msg, 1008, msgId);
+        return;
+
+    } else if (warnResult === metadata.blockReason.PERMBAN) {
+        const moderationSideBanReason = "Permban warn limit reached";
+        database.setMessageBlocker(anonId, metadata.blockReason.PERMBAN, moderationSideBanReason, "");
+
+        if (DMChannelId) {
+            const dm = new discord.DMChannel(client, {id: DMChannelId});
+            const anonUserSideBanReason = `You are receiving a warning for sending message ${msgId}\n` +
+                                          `Reason: ${reason}\n` +
+                                          `You have now exceeded the limit on the number of warns users can receive ` +
+                                          `before being permanently banned. You are permanently banned from sending ` +
+                                          `anonymous messages.`
+
+            dm.send(anonUserSideBanReason);
+            database.clearWarnCount(anonId, metadata.blockReason.PERMBAN);
+        }
+
+        replyTorMessageWithStatus(msg, 1008, msgId);
+        return;
+
+    } else if (warnResult === -1) {
+        replyTorMessageWithStatus(msg, 2015);
+        return;
+    }
+
+    const tempWarnCount = database.getWarnCount(anonId, metadata.blockReason.TEMPBAN);
+    const permWarnCount = database.getWarnCount(anonId, metadata.blockReason.PERMBAN);
+
+    if (DMChannelId) {
+        const dm = new discord.DMChannel(client, { id: DMChannelId });
+        const warnsUntilTempban = database.getTempbanWarnLimit() - tempWarnCount;
+        const warnsUntilPermban = database.getPermbanWarnLimit() - permWarnCount;
+
+        let message = `You are receiving a warning for sending message ${msgId}\n` +
+                      `Reason: ${reason}\n`;
+
+        if (warnsUntilPermban > warnsUntilTempban) {
+            message += `You have ${warnsUntilTempban} warns left until you are temporarily banned from sending ` +
+                       `anonymous messages.\n`;
+        }
+
+        message += `You have ${warnsUntilPermban} warns left until you are permanently banned from sending anonymous ` +
+                   `messages.`
+
+        dm.send(message);
+        replyTorMessageWithStatus(msg, 1008, msgId);
+    }
+
+}
+
+function handleWarnLimitCommand(params, msg) {
+    if (params.length != 4 || !isNumeric(params[2]) || !isNumeric(params[3])) {
+        replyTorMessageWithStatus(msg, 2012);
+        return;
+    }
+
+    const tempLimit = parseInt(params[2]);
+    const permLimit = parseInt(params[3]);
+
+    if (tempLimit === 0 || permLimit === 0) {
+        replyTorMessageWithStatus(msg, 2018);
+        return;
+    }
+
+    database.setWarnLimits(tempLimit, permLimit);
+    message = `Tempban warn limit set  to ${tempLimit}\nPermban warn limit set to ${permLimit}`;
+    msg.channel.send(message);
+
+    const warnedUsersInfo= database.getWarnedUsersInfo();
+
+    let warnChangeAnnouncement = `The limits on the number of warns users can receive before being temporarily and ` +
+                                 `permanently banned has changed. The warn limit for temporary bans is now ` +
+                                 `${tempLimit} warns and the warn limit for permanent bans is now ${permLimit} ` +
+                                 `warns.\n\n`;
+
+    let DMChannelId;
+    let dm;
+    let response;
+    let anonId;
+
+    for (let i = 0; i < warnedUsersInfo.length; i++) {
+        anonId = warnedUsersInfo[i].anon_id;
+        DMChannelId = database.getDmChannel(anonId);
+        dm = new discord.DMChannel(client, { id: DMChannelId });
+
+        const tempCount = warnedUsersInfo[i].temp_count;
+        const permCount = warnedUsersInfo[i].perm_count;
+
+        if (!DMChannelId) {
+            continue;
+        }
+
+        if (warnedUsersInfo[i].perm_count >= permLimit) {
+            database.setMessageBlocker(anonId, metadata.blockReason.PERMBAN, "Permban warn limit reached", "");
+            database.clearWarnCount(anonId, metadata.blockReason.PERMBAN);
+
+            response = warnChangeAnnouncement +
+                      `Since you have have received a total of ${permCount} warns, you have been permanently banned ` +
+                      `from sending anonymous messages.`;
+
+        } else if (warnedUsersInfo[i].temp_count >= tempLimit) {
+            let unbanTime = moment().utc();
+            unbanTime = moment(unbanTime).add(database.getWarnTempbanDuration(), "days");
+
+            database.setMessageBlocker(anonId, metadata.blockReason.TEMPBAN,
+                "Tempban warn limit reached", unbanTime.format("DD MM YYYY HH:mm:ss"));
+            database.clearWarnCount(anonId, metadata.blockReason.TEMPBAN);
+
+            response = warnChangeAnnouncement +
+                      `Since you have have received ${tempCount} warns since your last temporary ban cycle ` +
+                      `started, you have been temporarily banned from sending anonymous messages. Your ban will be ` +
+                      `lifted in ${database.getWarnTempbanDuration()} days.`;
+        } else {
+            let warnsUntilTempban = tempLimit - tempCount;
+            let warnsUntilPermban = permLimit - permCount;
+
+            response = warnChangeAnnouncement +
+                      `After these changes:\n`;
+
+            if (warnsUntilPermban > warnsUntilTempban) {
+                response += `You have ${warnsUntilTempban} warns left until you are temporarily banned from sending ` +
+                            `anonymous messages.\n`;
+            }
+
+            response += `You have ${warnsUntilPermban} warns left until you are permanently banned from sending ` +
+                        `anonymous messages.`;
+        }
+        dm.send(response);
+    }
+}
+
+function handleSetWarnTempbanDuration(params, msg) {
+    if (params.length != 3 || !isNumeric(params[2])) {
+        replyTorMessageWithStatus(msg, 2013);
+        return;
+    }
+
+    const days = parseInt(params[2]);
+    if (days === 0) {
+        replyTorMessageWithStatus(msg, 2019);
+        return;
+    }
+
+    database.setWarnTempbanDuration(days);
+    replyTorMessageWithStatus(msg, 1009, `${days} days`);
+}
+
 // Helpers
 
 function reconstructMessage(params) {
     return params.join(" ");
+}
+
+function concatRegex(regex1, regex2) {
+    return new RegExp(regex1.source + regex2.source);
 }
 
 function replyTorMessageWithStatus(msg, status, suffix, content) {

--- a/database.js
+++ b/database.js
@@ -168,8 +168,8 @@ function getMessageUrlByNumber(num) {
 
 function messageNumberIsRepliable(num) {
 
-  let stmt = db.prepare("SELECT * FROM messages WHERE number = ?");
-  let result = stmt.get(num);
+  const stmt = db.prepare("SELECT * FROM messages WHERE number = ?");
+  const result = stmt.get(num);
 
   if (typeof(result) === "undefined") {
     return false;
@@ -336,7 +336,7 @@ function setWarnLimits(tempLimit, permLimit) {
 }
 
 function setWarnTempbanDuration(duration) {
-  let stmt = db.prepare("UPDATE warnSettings SET tempban_duration = ? WHERE rownum = 1");
+  const stmt = db.prepare("UPDATE warnSettings SET tempban_duration = ? WHERE rownum = 1");
   stmt.run(duration);
 }
 

--- a/database.js
+++ b/database.js
@@ -351,12 +351,12 @@ function getPermbanWarnLimit() {
 }
 
 function getWarnTempbanDuration() {
-  let const = db.prepare("SELECT * FROM warnSettings");
+  const stmt = db.prepare("SELECT * FROM warnSettings");
   return stmt.get().tempban_duration;
 }
 
 function getWarnedUsersInfo() {
-  let const = db.prepare("SELECT * FROM warns");
+  const stmt = db.prepare("SELECT * FROM warns");
   return stmt.all();
 }
 

--- a/database.js
+++ b/database.js
@@ -2,7 +2,6 @@
 const sqlite = require("better-sqlite3");
 const db = new sqlite("./dbfile");
 const metadata = require("./metadata.js");
-const discord = require("discord.js");
 
 function getOrSetEncryptor(bufferIv) {
   // Can only have one encryptor value. Get an existing, or set and return passed
@@ -77,7 +76,7 @@ function getMessageBlocker(encryptedUser) {
 function isBanned(encrypedUser) {
 
   const stmt = db.prepare("SELECT * FROM messageBlocker WHERE encryptedUserId = ?");
-  return typeof(stmt.get(encrypedUser)) != "undefined";
+  return typeof(stmt.get(encrypedUser)) !== "undefined";
 
 }
 
@@ -165,32 +164,6 @@ function getMessageUrlByNumber(num) {
   );
   const result = stmt.get();
   return result.message_url;
-}
-
-function messageNumberIsValid(num) {
-
-  let stmt = db.prepare(
-      "SELECT * FROM messages WHERE number=(SELECT MIN(number) from messages)"
-  );
-  let result = stmt.get();
-  if (!result) {
-    return "";
-  }
-  const firstRepliableMessageNumber = result.number;
-
-  stmt = db.prepare(
-      "SELECT * FROM messages WHERE number=(SELECT MAX(number) from messages)"
-  );
-  result = stmt.get();
-  const lastRepliableMessageNumber = result.number;
-
-  // Return false if message number is out of bounds
-  if (firstRepliableMessageNumber < num && num < lastRepliableMessageNumber) {
-    return true;
-  }
-
-  return false
-
 }
 
 function messageNumberIsRepliable(num) {
@@ -282,7 +255,7 @@ function addWarn(msgId) {
 
   const anonId = getAnonIdFromMsgId(msgId);
   let stmt = db.prepare("SELECT * FROM warns WHERE anon_id = ?");
-  let result = stmt.get(anonId);
+  const result = stmt.get(anonId);
 
   if (typeof(result) === "undefined") {
     stmt = db.prepare("INSERT INTO warns VALUES(?, ?, ?)");
@@ -318,8 +291,8 @@ function addWarn(msgId) {
 }
 
 function isWarnable(msgId) {
-  let stmt = db.prepare("SELECT * FROM messages WHERE number = ?");
-  let result = stmt.get(msgId);
+  const stmt = db.prepare("SELECT * FROM messages WHERE number = ?");
+  cnost result = stmt.get(msgId);
 
   if (typeof(result) === "undefined") {
     return false;
@@ -333,7 +306,7 @@ function isWarnable(msgId) {
 }
 
 function getWarnCount(anonId, banType) {
-  let stmt, result;
+  let stmt;
   if (banType === metadata.blockReason.TEMPBAN) {
     stmt = db.prepare("SELECT temp_count FROM warns WHERE anon_id = ?");
     return stmt.get(anonId).temp_count;
@@ -348,18 +321,17 @@ function getWarnCount(anonId, banType) {
 function clearWarnCount(anonId, banType) {
   let stmt;
 
-  if (banType == metadata.blockReason.TEMPBAN) {
+  if (banType === metadata.blockReason.TEMPBAN) {
     stmt = db.prepare("UPDATE warns SET temp_count = 0 WHERE anon_id = ?");
     stmt.run(anonId);
-  } else if (banType == metadata.blockReason.PERMBAN) {
+  } else if (banType === metadata.blockReason.PERMBAN) {
     stmt = db.prepare("UPDATE warns SET temp_count = 0, perm_count = 0 WHERE anon_id = ?");
     stmt.run(anonId);
   }
 }
 
 function setWarnLimits(tempLimit, permLimit) {
-  let stmt;
-  stmt = db.prepare("UPDATE warnSettings SET tempban_limit = ?, permban_limit = ? WHERE rownum = 1");
+  const stmt = db.prepare("UPDATE warnSettings SET tempban_limit = ?, permban_limit = ? WHERE rownum = 1");
   stmt.run(tempLimit, permLimit);
 }
 
@@ -369,22 +341,22 @@ function setWarnTempbanDuration(duration) {
 }
 
 function getTempbanWarnLimit() {
-  let stmt = db.prepare("SELECT * FROM warnSettings");
+  const stmt = db.prepare("SELECT * FROM warnSettings");
   return stmt.get().tempban_limit;
 }
 
 function getPermbanWarnLimit() {
-  let stmt = db.prepare("SELECT * FROM warnSettings");
+  const stmt = db.prepare("SELECT * FROM warnSettings");
   return stmt.get().permban_limit;
 }
 
 function getWarnTempbanDuration() {
-  let stmt = db.prepare("SELECT * FROM warnSettings");
+  let const = db.prepare("SELECT * FROM warnSettings");
   return stmt.get().tempban_duration;
 }
 
 function getWarnedUsersInfo() {
-  let stmt = db.prepare("SELECT * FROM warns");
+  let const = db.prepare("SELECT * FROM warns");
   return stmt.all();
 }
 
@@ -490,10 +462,6 @@ function initializeTables() {
   );
   stmt.run();
 
-
-
-
-
   // Table for warns
   stmt = db.prepare(
       "CREATE TABLE IF NOT EXISTS warns (anon_id TEXT NOT NULL, " +
@@ -501,24 +469,21 @@ function initializeTables() {
   );
   stmt.run();
 
-  // Table for individual variables
-
+  // Table for warn settings variables
   stmt = db.prepare(
-      "CREATE TABLE IF NOT EXISTS warnSettings (rownum INTEGER, tempban_limit INTEGER, permban_limit INTEGER, tempban_duration INTEGER)"
+      "CREATE TABLE IF NOT EXISTS warnSettings (rownum INTEGER, " +
+      "tempban_limit INTEGER, permban_limit INTEGER, tempban_duration INTEGER)"
   );
   stmt.run();
 
   // Initialize with -1's
   stmt = db.prepare("SELECT * FROM warnSettings");
-  let result = stmt.get();
+  const result = stmt.get();
 
   if (typeof(result) === "undefined") {
     stmt = db.prepare("INSERT INTO warnSettings VALUES (1, -1, -1, -1)");
     stmt.run();
   }
-
-
-
 
 }
 

--- a/database.js
+++ b/database.js
@@ -292,7 +292,7 @@ function addWarn(msgId) {
 
 function isWarnable(msgId) {
   const stmt = db.prepare("SELECT * FROM messages WHERE number = ?");
-  cnost result = stmt.get(msgId);
+  const result = stmt.get(msgId);
 
   if (typeof(result) === "undefined") {
     return false;

--- a/errors.js
+++ b/errors.js
@@ -11,28 +11,49 @@ const errorMap = {
       {
         name: "Setting channel destinations",
         value:
-          "!anon set log #channel -> Sets the logger channel for the bot to dump submitted messages with anon IDs\n" +
-          "!anon set anon #channel -> Sets the anon channel for the bot to write to\n" +
-          "!anon set deeptalks #channel -> Sets the deep talk channel for the bot to write to\n" +
-          "!anon set #anon-msgs #deep-talks #anon-logs -> Sets all three channels at once",
+          "• `!anon set log #channel`\n" +
+          "Description: Sets the logger channel for the bot to dump submitted messages with anon IDs\n\n" +
+          "• `!anon set anon #channel`\n" +
+          "Description: Sets the anon channel for the bot to write to\n\n" +
+          "• `!anon set deeptalks #channel`\n" +
+          "Description: Sets the deep talk channel for the bot to write to\n\n" +
+          "• `!anon set #anon-msgs #deep-talks #anon-logs`\n" +
+          "Description: Sets all three channels at once",
       },
       {
         name: "Timers",
         value:
-          "!anon slowmode seconds -> Adds a slowmode to the messages sent to the anon chat. 0 seconds turns slowmode off",
+          "• `!anon slowmode seconds`\n" +
+          "Description: Adds a slowmode to the messages sent to the anon chat. 0 seconds turns slowmode off",
       },
       {
-        name: "Bans",
+        name: "Bans and warns",
         value:
-          "!anon tempban msg_id seconds reason -> Temporarily bans a user for some amount of time with a reason\n" +
-          "!anon permban msg_id reason -> Permanently bans a user with a reason\n" +
-          "!anon unban [msg_id/anon_id] -> Unbans a user\n" +
-          "!anon banlist -> Display all banned users\n" +
-          "NOTE: User will see ban reason when they attempt to send a message to the bot",
+          "• `!anon tempban msg_id days reason`\n" +
+          "Description: Temporarily bans a user for some amount of time with a reason\n\n" +
+          "• `!anon permban msg_id reason`\n" +
+          "Description: Permanently bans a user with a reason\n\n" +
+          "• `!anon unban [msg_id/anon_id]`\n" +
+          "Description: Unbans a user\n\n" +
+          "• `!anon banlist`\n" +
+          "Description: Display all banned users\n" +
+          "NOTE: The user will be notified of the ban along with the reason for the ban\n\n" +
+          "• `!anon warn msg_id reason`\n" +
+          "Description: Warns a user. A reason for the warn may optionally be provided.\n" +
+          "NOTE: In order to issue warns, the settings for warnings must first be configured with the `!anon " +
+          "warnlimit tempLimit permLimit` command and the `!anon wtd days` command.\n\n" +
+          "• `!anon warnlimit tempLimit permLimit`\n" +
+          "Description: Sets the number of warns a user can receive before being tempbanned and permbanned, " +
+          "respectively.\n\n" +
+          "• `!anon wtd days`\n" +
+          "Description: Sets the warn tempban duration, which is the number of days a user will be tempbanned for if " +
+          "they exceed the tempban warn limit",
       },
       {
         name: "Filters",
-        value: "!anon slur word -> Adds a slur to the block list",
+        value:
+          "• `!anon slur word`\n" +
+          "Description: Adds a slur to the block list",
       }
     )
     .setTimestamp(),
@@ -89,6 +110,8 @@ const errorMap = {
   1005: "Anon user was temp banned with reason: ",
   1006: "Anon user was perm banned with reason: ",
   1007: "Following anon user was unbanned: ",
+  1008: "User was warned for sending message ",
+  1009: "Warn tempban duration set to ",
   // Input configuration problems
   2000: "Command unrecognized. Run !anon help for all available commands",
   2001: "Nothing provided after set, or the channel target was incorrect. Run !anon help for all available options",
@@ -96,22 +119,42 @@ const errorMap = {
   2003: "Anon channel not found or not provided. Make sure the channel is properly tagged (ex: #anonymous-messages)",
   2004: "Deep talks channel not found or not provided. Make sure the channel is properly tagged (ex: #deep-talks)",
   2005: "Improper slowmode command provided, or the number is negative. Follow the format of !anon slowmode second",
-  2006: "Improper tempban command provided. Follow the format of !anon tempban msgId seconds reason",
+  2006: "Improper tempban command provided. Follow the format of !anon tempban msgId days reason",
   2007: "Improper permban command provided. Follow the format of !anon permban msgId reason",
   2008: "Improper unban command provided. Follow the format of !anon msgId user",
   2009: "Command unrecognized. Type in !help to see everything available to you",
   2010: "Improper msgId value provided. Please try again.",
-  2011:
+  2011: "Improper warn command provided. Follow the format of !anon warn msgId",
+  2012: "Improper warn limit command provided. Follow the format of !anon warnlimit tempbanLimit permbanLimit",
+  2013: "Improper warn tempban duration command provided. Follow the format of !anon wtd days",
+  2014:
     "The reply could not be sent. Either the message number is invalid, the message has been deleted, or the " +
     "message was sent before the reply command was introduced. As a reminder, the reply command is " +
     "`!send/send-deep (nsfw) reply msg_number_here your_message`. For example, `!send reply 123 hello`, or " +
     "`!send-deep nsfw reply 123 hello`.",
-  2012: "Please do not use WVAnon for hate speech. Rethink your life choices, please.",
+  2015:
+    "The message with the specified id is ineligible for warns. Either the message with that id does not exist or " +
+    "the user who sent the message has already received a warn for it.",
+  2016: "Please do not use WVAnon for hate speech. Rethink your life choices, please.",
+  2017:
+    "Warns cannot be issued until the settings for warnings have been fully set. To set up warnings, use:\n\n" +
+    "• `!anon warnlimit tempLimit permLimit`, where tempLimit is the number of warns a user receives before being " +
+    "tempbanned, and permLimit is the number of warns a user receives before being permbanned.\n\n" +
+    "• `!anon wtd duration`, where duration is the warnings temban duration, which is the number of days a user will " +
+    "tempbanned for after meeting the tempban warn limit.",
+  2018: "Improper warn limit settings: warn limits must be greater than zero",
+  2019: "The warnings tempban duration must be greater than 0",
+  2020: "The user who sent this message is currently banned and consequently cannot receive warns.",
+  2021: "User is already banned from sending anonymous messages",
   // Message blocks
   3000: "Slowmode is active. Try sending in ",
-  3001: "You've send too many messages within a short timeframe. Try again in ",
-  3002: "You've been temporarily banned from posting anon messages. Reason: ",
-  3003: "You've been permenantly banned from posting anon messages. Reason: ",
+  3001: "You've sent too many messages within a short timeframe. Try again in ",
+  3002: "You've been temporarily banned from posting anonymous messages.\nReason: ",
+  3003: "You've been permenantly banned from posting anonymous messages.\nReason: ",
+  // Warn and ban notifications
+  4000: "You have been temporarily banned.\nReason: ",
+  4001: "You have been permanently banned.\nReason: ",
+  4002: "You have been unbanned. Please remember to follow the rules of the server when sending anonymous messages.",
 };
 
 module.exports = {

--- a/timerhandler.js
+++ b/timerhandler.js
@@ -22,9 +22,8 @@ function configureTimersAndCheckIfCanSend(msg) {
           error.errorCode = 3002;
           error.suffix =
             record.explanation +
-            "\nBan lifts in " +
-            dateOfUnblock.diff(now, "seconds") +
-            " seconds";
+            "\nYour ban lifts on " +
+            dateOfUnblock.format("MMMM Do YYYY,[ at ]h:mm a [(UTC time)]");
         } else {
           database.deleteMessageBlocker(encryptedUser);
         }


### PR DESCRIPTION
## [WVA-040] Add warns

<!--- Please add in the issue number this PR is fixing below. If an issue does not exist, create one! --->

Fixes: #40

- [x] Has the code been formatted? Make sure you run `npx prettier --write .`
- [ ] Have dependencies/packages been added?

### Changes

A warn feature was added that allows admins/mods to issue warnings to users. Admins/mods are able to set "warn limits", which are the limits on the number of warns users receive before they get tempbanned and permbanned. If a user reaches the tempban warn limit, then they are tempbanned for a period of time which admins/mods can set. Once their ban is over, their warn count for tempbans is reset, but their overall warn count is kept. They will continue to get tempbanned after reaching the tempban warn limit over and over again until their overall warn count reaches the permban warn limit, after which they will be permbanned.
