### PR TITLE
Fixed issues with hate speech filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## V1.6 - June 2nd, 2021
+## V1.6 - June 20th, 2021
 
 1. Introduced a warnings feature that allows admins and mods to warn users for sending inappropriate messages.
+2. Fixed incorrect ban time and DM notification format for hate speech filter
 
 ## V1.5 - Apr 29th, 2021
 

--- a/bot.js
+++ b/bot.js
@@ -150,9 +150,9 @@ async function submitAnon(msg) {
     }
 
     if (!isCool(messageToSend)) {
-        replyTorMessageWithStatus(msg, 2016);
-        handleTempBan(msg, anonId, 86400, "Hate speech");
+        handleTempBan(msg, anonId, 1, "Hate speech (automatic filter)", false);
         sendLogMessage(`User ${anonId} has been temp banned for saying ${msg}`);
+        replyTorMessageWithStatus(msg, 2016);
         return;
     }
 
@@ -491,7 +491,7 @@ function handleSlowmodeCommand(params, msg) {
     );
 }
 
-function handleTempBan(msg, anonId, duration, reason) {
+function handleTempBan(msg, anonId, duration, reason, sendLogResponse = true) {
 
     if (database.isBanned(anonId)) {
         replyTorMessageWithStatus(msg, 2021);
@@ -509,9 +509,14 @@ function handleTempBan(msg, anonId, duration, reason) {
         reason,
         unbanTime.format("DD MM YYYY HH:mm:ss")
   );
+
   const banMsg =
-      reason + "\nUnban date on UTC: " + unbanTime.format("MMMM Do YYYY, [at] h:mm a");
-  replyTorMessageWithStatus(msg, 1005, banMsg);
+          reason + "\nUnban date on UTC: " + unbanTime.format("MMMM Do YYYY, [at] h:mm a");
+
+  if (sendLogResponse) {
+      replyTorMessageWithStatus(msg, 1005, banMsg);
+  }
+
   if (DMChannelId) {
       const dm = new discord.DMChannel(client, { id: DMChannelId });
       dm.send(errors.getError(4000, banMsg));


### PR DESCRIPTION
## [WVA-048] Hate speech tempbans are too long and the notification is improperly formatted

<!--- Please add in the issue number this PR is fixing below. If an issue does not exist, create one! --->

Fixes: #48

- [x] Has the code been formatted? Make sure you run `npx prettier --write .`
- [ ] Have dependencies/packages been added?

### Changes

The hate speech filter now only bans users for one day instead of for 86400 days, and the format for the DM notification to users upon being banned has been fixed.
